### PR TITLE
fix: remove unknown extraneous space

### DIFF
--- a/src/components/cursor.js
+++ b/src/components/cursor.js
@@ -3,7 +3,7 @@ const {h} = require('ink');
 function Cursor({cursorCharacter, isActive}) {
 	const c = isActive === true ?
 		`${cursorCharacter} ` :
-		' '.repeat(cursorCharacter.length + 1);
+		'\u00A0'.repeat(cursorCharacter.length + 1);
 	return (
 		<span>{c}</span>
 	);

--- a/test/test.js
+++ b/test/test.js
@@ -56,7 +56,7 @@ test('cursor', t => {
 			cursorCharacter="--->"
 			isActive={false}
 		/>
-	), '\u00A0\u00A0\u00A0\u00A0\u00A0');
+	), '\u00A0'.repeat(5));
 });
 
 test('called `onChange` when user pressed space key', t => {

--- a/test/test.js
+++ b/test/test.js
@@ -56,7 +56,7 @@ test('cursor', t => {
 			cursorCharacter="--->"
 			isActive={false}
 		/>
-	), '     ');
+	), '\u00A0\u00A0\u00A0\u00A0\u00A0');
 });
 
 test('called `onChange` when user pressed space key', t => {


### PR DESCRIPTION
I'm tackling a bug while trying to render checkbox

with the original space (`\u0020`), there is an extra space for non-active lines
![image](https://user-images.githubusercontent.com/1922462/29496222-9d20df28-85f8-11e7-81ed-b0ed95c1a2fd.png)

changing it to any character fixes the extra space
![image](https://user-images.githubusercontent.com/1922462/29496237-da3c6206-85f8-11e7-812b-9545742f3cb7.png)

so I came up with change it `\u0020` to `\u00A0` which is also empty
![image](https://user-images.githubusercontent.com/1922462/29496242-fe029430-85f8-11e7-8fbd-695d6b1cc902.png)


