### PR TITLE
use newer ink version

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,13 +82,13 @@
 		"babel-plugin-transform-react-jsx": "^6.24.1",
 		"eslint-config-xo-react": "^0.13.0",
 		"eslint-plugin-react": "^7.1.0",
-		"ink": "0.3.0",
+		"ink": "0.5.1",
 		"sinon": "^2.3.7",
 		"standard": "^10.0.2",
 		"xo": "^0.18.2"
 	},
 	"peerDependencies": {
-		"ink": "^0.3.0"
+		"ink": "^0.3.0 || ^0.5.0"
 	},
 	"dependencies": {
 		"figures": "^2.0.0",


### PR DESCRIPTION
I'm using `ink-checkbox-list` happily with the current `ink@0.5.1` and have no problems. There are only some peer dependency warnings.

```
npm WARN ink-checkbox-list@1.3.1 requires a peer of ink@^0.3.0 but none is installed. You must install peer dependencies yourself.
```

This PR should get rid of them.